### PR TITLE
Harden against nulls and exceptions crashing VS

### DIFF
--- a/src/WebLinks.VisualStudio/CommandManager.cs
+++ b/src/WebLinks.VisualStudio/CommandManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.Design;
+using System.Diagnostics;
 using Microsoft.VisualStudio.Shell;
 
 namespace Mjcheetham.WebLinks.VisualStudio
@@ -42,13 +43,29 @@ namespace Mjcheetham.WebLinks.VisualStudio
         {
             if (sender is OleMenuCommand command && command.Enabled)
             {
-                this.InvokeInternal();
+                try
+                {
+                    this.InvokeInternal();
+                }
+                catch (Exception ex)
+                {
+                    // Swallow exception to prevent VS crash
+                    Trace.WriteLine($"Unhandled exception in VsCommand.Invoke:{Environment.NewLine}{ex}");
+                }
             }
         }
 
         public void QueryStatus(object sender, EventArgs args)
         {
-            this.QueryStatusInternal(sender as OleMenuCommand);
+            try
+            {
+                this.QueryStatusInternal(sender as OleMenuCommand);
+            }
+            catch (Exception ex)
+            {
+                // Swallow exception to prevent VS crash
+                Trace.WriteLine($"Unhandled exception in VsCommand.QueryStatus:{Environment.NewLine}{ex}");
+            }
         }
     }
 }

--- a/src/WebLinks.VisualStudio/Commands.cs
+++ b/src/WebLinks.VisualStudio/Commands.cs
@@ -25,14 +25,20 @@ namespace Mjcheetham.WebLinks.VisualStudio
             if (_webLinksService != null)
             {
                 string filePath = SelectionHelper.GetSelectedFilePath(_serviceProvider);
+                if (string.IsNullOrWhiteSpace(filePath))
+                {
+                    return;
+                }
 
                 string providerName = _webLinksService.GetProviderForFile(filePath);
-                if (!string.IsNullOrWhiteSpace(providerName))
+                if (string.IsNullOrWhiteSpace(providerName))
                 {
-                    command.Enabled = true;
-                    command.Visible = true;
-                    command.Text = string.Format(Resources.CopyWebLink_Command_ProviderFormat, providerName);
+                    return;
                 }
+
+                command.Enabled = true;
+                command.Visible = true;
+                command.Text = string.Format(Resources.CopyWebLink_Command_ProviderFormat, providerName);
             }
         }
 
@@ -41,6 +47,11 @@ namespace Mjcheetham.WebLinks.VisualStudio
             if (_webLinksService != null)
             {
                 string filePath = SelectionHelper.GetSelectedFilePath(_serviceProvider);
+                if (string.IsNullOrWhiteSpace(filePath))
+                {
+                    return;
+                }
+
                 string url = _webLinksService.GetFileUrl(filePath);
                 Clipboard.SetText(url);
             }
@@ -68,14 +79,20 @@ namespace Mjcheetham.WebLinks.VisualStudio
             if (_webLinksService != null)
             {
                 string filePath = SelectionHelper.GetSelectedFilePath(_serviceProvider);
+                if (string.IsNullOrWhiteSpace(filePath))
+                {
+                    return;
+                }
 
                 string providerName = _webLinksService.GetProviderForFile(filePath);
-                if (!string.IsNullOrWhiteSpace(providerName))
+                if (string.IsNullOrWhiteSpace(providerName))
                 {
-                    command.Enabled = true;
-                    command.Visible = true;
-                    command.Text = string.Format(Resources.OpenInWeb_Command_ProviderFormat, providerName);
+                    return;
                 }
+
+                command.Enabled = true;
+                command.Visible = true;
+                command.Text = string.Format(Resources.OpenInWeb_Command_ProviderFormat, providerName);
             }
         }
 
@@ -84,6 +101,11 @@ namespace Mjcheetham.WebLinks.VisualStudio
             if (_webLinksService != null)
             {
                 string filePath = SelectionHelper.GetSelectedFilePath(_serviceProvider);
+                if (string.IsNullOrWhiteSpace(filePath))
+                {
+                    return;
+                }
+
                 string url = _webLinksService.GetFileUrl(filePath);
                 BrowserHelper.OpenBrowser(url);
             }
@@ -111,14 +133,20 @@ namespace Mjcheetham.WebLinks.VisualStudio
             if (_webLinksService != null)
             {
                 var selection = SelectionHelper.GetEditorSelection(_serviceProvider);
+                if (selection == null)
+                {
+                    return;
+                }
 
                 string providerName = _webLinksService.GetProviderForFile(selection?.FilePath);
-                if (!string.IsNullOrWhiteSpace(providerName))
+                if (string.IsNullOrWhiteSpace(providerName))
                 {
-                    command.Enabled = true;
-                    command.Visible = true;
-                    command.Text = string.Format(Resources.CopyWebLink_Command_ProviderFormat, providerName);
+                    return;
                 }
+
+                command.Enabled = true;
+                command.Visible = true;
+                command.Text = string.Format(Resources.CopyWebLink_Command_ProviderFormat, providerName);
             }
         }
 
@@ -127,6 +155,10 @@ namespace Mjcheetham.WebLinks.VisualStudio
             if (_webLinksService != null)
             {
                 var selection = SelectionHelper.GetEditorSelection(_serviceProvider);
+                if (selection == null)
+                {
+                    return;
+                }
 
                 string url = _webLinksService.GetFileSelectionUrl(
                     selection.FilePath,
@@ -161,14 +193,20 @@ namespace Mjcheetham.WebLinks.VisualStudio
             if (_webLinksService != null)
             {
                 var selection = SelectionHelper.GetEditorSelection(_serviceProvider);
-
-                string providerName = _webLinksService.GetProviderForFile(selection?.FilePath);
-                if (!string.IsNullOrWhiteSpace(providerName))
+                if (selection == null)
                 {
-                    command.Enabled = true;
-                    command.Visible = true;
-                    command.Text = string.Format(Resources.OpenInWeb_Command_ProviderFormat, providerName);
+                    return;
                 }
+
+                string providerName = _webLinksService.GetProviderForFile(selection.FilePath);
+                if (string.IsNullOrWhiteSpace(providerName))
+                {
+                    return;
+                }
+
+                command.Enabled = true;
+                command.Visible = true;
+                command.Text = string.Format(Resources.OpenInWeb_Command_ProviderFormat, providerName);
             }
         }
 
@@ -177,6 +215,10 @@ namespace Mjcheetham.WebLinks.VisualStudio
             if (_webLinksService != null)
             {
                 var selection = SelectionHelper.GetEditorSelection(_serviceProvider);
+                if (selection == null)
+                {
+                    return;
+                }
 
                 string url = _webLinksService.GetFileSelectionUrl(
                     selection.FilePath,

--- a/src/WebLinks/GitHelpers.cs
+++ b/src/WebLinks/GitHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using LibGit2Sharp;
 
 namespace Mjcheetham.WebLinks
@@ -7,6 +8,11 @@ namespace Mjcheetham.WebLinks
     {
         public static string GetRepositoryPath(string filePath)
         {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                return null;
+            }
+
             const string gitDirPathPart = ".git\\";
             string raw = Repository.Discover(filePath);
 
@@ -20,6 +26,12 @@ namespace Mjcheetham.WebLinks
 
         public static TrackingInfo GetTrackingInfoForHead(string repositoryPath)
         {
+            if (!Repository.IsValid(repositoryPath))
+            {
+                Debug.Fail("Invalid repository path");
+                return null;
+            }
+
             using (var repository = new Repository(repositoryPath))
             {
                 Branch head = repository.Head;

--- a/src/WebLinks/GitWebLinksService.cs
+++ b/src/WebLinks/GitWebLinksService.cs
@@ -15,6 +15,11 @@ namespace Mjcheetham.WebLinks
 
         public string GetProviderForFile(string filePath)
         {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                return null;
+            }
+
             if (_providers.Count == 0)
             {
                 return null;
@@ -44,6 +49,11 @@ namespace Mjcheetham.WebLinks
 
         public string GetFileUrl(string filePath)
         {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                return null;
+            }
+
             string repositoryPath = GitHelpers.GetRepositoryPath(filePath);
             var trackingInfo = GitHelpers.GetTrackingInfoForHead(repositoryPath);
 


### PR DESCRIPTION
Check for null paths and selections, and guard against handing a `null` file path to `LibGit2Sharp::Repository.Discover`; it crashes!

Harden commands to prevent exceptions leaking out of WebLinks and crashing Visual Studio.

Fixes #4 