### PR TITLE
Rename VSTS to Azure DevOps and support new domain name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ selection in a file hosted in a remote Git repository.
 ### Supported Git Hosting Providers
 
 - [x] GitHub
-- [x] Visual Studio Team Services
+- [x] Azure DevOps (formerly Visual Studio Team Services)
 - [ ] ..more to follow...
 
 ## Building

--- a/src/WebLinks/AzureDevOpsWebProvider.cs
+++ b/src/WebLinks/AzureDevOpsWebProvider.cs
@@ -3,15 +3,21 @@ using System.Collections.Generic;
 
 namespace Mjcheetham.WebLinks
 {
-    internal class VstsWebProvider : IWebProvider
+    internal class AzureDevOpsWebProvider : IWebProvider
     {
-        public string Name => "Team Services";
+        public string Name => "Azure DevOps";
 
         public bool CanHandle(string repositoryUrl)
         {
             var uri = new Uri(repositoryUrl);
+            string hostName = uri.Host;
 
-            if (uri.Host.EndsWith(".visualstudio.com", StringComparison.OrdinalIgnoreCase))
+            if (StringComparer.OrdinalIgnoreCase.Equals(hostName, "dev.azure.com"))
+            {
+                return true;
+            }
+
+            if (hostName.EndsWith(".visualstudio.com", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/src/WebLinks/GitWebLinksService.cs
+++ b/src/WebLinks/GitWebLinksService.cs
@@ -8,7 +8,7 @@ namespace Mjcheetham.WebLinks
         private readonly ICollection<IWebProvider> _providers = new IWebProvider[]
         {
             new GitHubWebProvider(),
-            new VstsWebProvider(),
+            new AzureDevOpsWebProvider(),
         };
 
         #region IWebLinksService

--- a/src/WebLinks/WebLinks.csproj
+++ b/src/WebLinks/WebLinks.csproj
@@ -51,6 +51,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AzureDevOpsWebProvider.cs" />
     <Compile Include="GitHelpers.cs" />
     <Compile Include="GitHubWebProvider.cs" />
     <Compile Include="IWebLinksService.cs" />
@@ -59,7 +60,6 @@
     <Compile Include="PathHelpers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UriHelper.cs" />
-    <Compile Include="VstsWebProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Visual Studio Team Services has been renamed to Azure DevOps.
See the announcement blog post [here](https://aka.ms/azurevsts).

Rename the VSTSWebProvider to AzureDevOpsProvider and change the user visible service name from "Team Services" to "Azure DevOps".